### PR TITLE
Emyt docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # IDE
 .idea
+.vscode
 
 # Moxie Binaries
 builds/moxie_osx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.19
+
+WORKDIR /app
+
+# Dependencies + checksum
+COPY go.mod go.sum ./
+
+# Install them
+RUN go mod download
+
+# Copy project
+COPY . ./
+
+# Build package
+RUN cd cmd/ && CGO_ENABLED=1 GOOS=linux go build -o ../docker-emyt
+
+EXPOSE 80
+
+CMD [ "/app/docker-emyt" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN go mod download
 COPY . ./
 
 # Build package
-RUN cd cmd/ && CGO_ENABLED=1 GOOS=linux go build -o ../docker-emyt
+RUN cd cmd/ && CGO_ENABLED=1 GOOS=linux go build --ldflags "-s -w" -o ../docker-emyt
 
-EXPOSE 80
+EXPOSE 9999
+EXPOSE 9000
 
 CMD [ "/app/docker-emyt" ]


### PR DESCRIPTION
## TODO

For some reason app is not running on the `app.yml` port (9000), but 9999. Also is not returining the sample app: http://app1.localhost:9999 

## Purpose

Enable Emyt as a docker image, thus we can dockerize web apps, and/or docker-compose several apps.